### PR TITLE
feat: add smart contract compatible with beta 3 network

### DIFF
--- a/beta-3/Forc.lock
+++ b/beta-3/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'blackgold-smart-contract-beta-3'
+source = 'member'
+dependencies = ['std']
+
+[[package]]
+name = 'core'
+source = 'path+from-root-67732E1923984E25'
+
+[[package]]
+name = 'std'
+source = 'git+https://github.com/fuellabs/sway?tag=v0.37.3#d09ef912828f5fc7193501ccf8a0d0fb0f36a821'
+dependencies = ['core']

--- a/beta-3/Forc.toml
+++ b/beta-3/Forc.toml
@@ -1,0 +1,7 @@
+[project]
+authors = ["timotej"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "blackgold-smart-contract-beta-3"
+
+[dependencies]

--- a/beta-3/src/main.sw
+++ b/beta-3/src/main.sw
@@ -1,0 +1,94 @@
+contract;
+use std::auth::{ AuthError, msg_sender };
+use std::hash::{keccak256, sha256}; 
+use std::logging::log;
+
+
+enum SellerType {
+    Store: (),
+    Organisation: (),
+}
+
+abi BlackGold {
+
+    //functions for organisations
+    #[storage(read, write)]
+    fn new_organisation(creator_id: str[1], owner: str[1], stores: (str[1], str[1], str[1], str[1], str[1]));
+
+    #[storage(read)]
+    fn get_org(org_id: u64) -> Organisation;
+    //functions from user to org
+    #[storage(read, write)]
+    fn user_org_update_points(id: u64, points_spent: u64, seller_type: SellerType) -> u64;
+
+    #[storage(read,write)]
+    fn user_spend_points(id: u64, points_spent: u64, seller_type: SellerType) -> u64;
+
+    #[storage(read, write)]
+    fn update_org(org_id: u64, owner: str[1] , stores: (str[1], str[1], str[1], str[1], str[1]), exists: bool);
+}
+
+
+
+pub struct Organisation {
+    id: u64,
+    owner: str[1],
+    stores: (str[1], str[1], str[1], str[1], str[1]),
+    exists: bool,
+}
+
+storage {
+    organisation_counter: u64 = 0,
+    id_to_organisation: StorageMap<u64, Organisation> = StorageMap {},
+    user_seller_to_points: StorageMap<(Identity,SellerType,u64), u64> = StorageMap {},
+}
+
+impl BlackGold for Contract {
+    #[storage(read, write)]
+    fn new_organisation(creator_id: str[1], owner: str[1] , stores: (str[1], str[1], str[1], str[1], str[1])) {
+        storage.organisation_counter += 1;
+        let new_org: Organisation = Organisation {
+            id: storage.organisation_counter,
+            owner: owner,
+            stores: stores,
+            exists: true,
+        };
+        storage.id_to_organisation.insert(storage.organisation_counter, new_org);
+
+    }
+    #[storage(read)]
+    fn get_org(org_id: u64) -> Organisation {
+        return storage.id_to_organisation.get(org_id).unwrap();
+    }
+
+    #[storage(read, write)]
+    fn user_org_update_points(id: u64, points_added: u64, seller_type: SellerType) -> u64 {
+        let points = storage.user_seller_to_points.get((msg_sender().unwrap(), seller_type, id)).unwrap_or(0);
+        let user_points_updated = points + points_added;
+        storage.user_seller_to_points.insert((msg_sender().unwrap(), seller_type, id), user_points_updated);
+        return user_points_updated;
+    }
+
+   #[storage(read,write)]
+   fn user_spend_points(id: u64, points_spent: u64, seller_type: SellerType) -> u64 {
+        let points = storage.user_seller_to_points.get((msg_sender().unwrap(), seller_type, id)).unwrap_or(0);
+        let user_points_spent = points - points_spent; 
+        storage.user_seller_to_points.insert((msg_sender().unwrap(), seller_type, id ), user_points_spent);
+        return user_points_spent;
+   }
+
+   #[storage(read, write)]
+   fn update_org(org_id: u64, owner: str[1] , stores: (str[1], str[1], str[1], str[1], str[1]), exists: bool) {
+        let updated_org: Organisation = Organisation {
+            id: org_id,
+            owner: owner,
+            stores: stores,
+            exists: true,
+        };
+        storage.id_to_organisation.insert(org_id, updated_org);
+   }
+
+
+
+
+}


### PR DESCRIPTION
# Description
Add new version of smart contract that is compatible with beta-3 testnet

- Made limited amount of spaces available for merchants in organisation
- Modified the `user_seller_to_points` to store both Stores and Organisation points
- Adapted some functions to the limitations of beta-3 (eg. `get_org`)